### PR TITLE
Use the fzf preview feature to see pods

### DIFF
--- a/kns
+++ b/kns
@@ -18,7 +18,7 @@ namespace="$(kubectl config get-contexts "$current" | awk "/$current/ {print \$5
 if [ -z "$namespace" ]; then
   namespace="default"
 fi
-selected=$( (kubectl get namespaces -o name | sed "s-namespaces/--"; echo $namespace ) | fzf -0 -1 --tac -q "${1:-""}" --prompt "$current> ")
+selected=$( (kubectl get namespaces -o name | sed "s-namespaces/--"; echo $namespace ) | fzf -0 -1 --tac -q "${1:-""}" --prompt "$current> " --preview "kubectl --namespace {} get pods")
 if [ ! -z "$selected" ]; then
   kubectl config set-context "$current" "--namespace=$selected" >/dev/null
   echo "Set context namespace to \"$selected\""


### PR DESCRIPTION
This is a really cool feature in _fzf_ where you can run a command to generate a preview. In this case, it'll show the pods when scrolling through namespaces.