### PR TITLE
Add installation instructions for ktx

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,7 @@ That's it! Done! :raised_hands:
 
 For those of you that deal with a lot of clusters regularly, there's also `ktx` to switch
 between contexts. It does not connect to any api-server, but only displays information from
-`kubectl` configuration. It is included in the homebrew package (see above).
+`kubectl` configuration. It is included in the homebrew package (see above) or you can manually install it too:
+```bash
+curl https://raw.githubusercontent.com/blendle/kns/master/bin/ktx -o /usr/local/bin/ktx && chmod +x $_
+```


### PR DESCRIPTION
Since `brew tap` isn't working, I installed it manually but missed `ktx`. This helps installing it.