### PR TITLE
fix: handle non-existing current context

### DIFF
--- a/bin/ktx
+++ b/bin/ktx
@@ -12,13 +12,7 @@ if [ ! -x "$(which fzf 2>/dev/null)" ]; then
   exit 1
 fi
 
-exit_code=0; kubectl config current-context || exit_code=$?
-if [[ $exit_code -eq 0 ]]; then
-  current="$(kubectl config current-context)"
-else
-  current=""
-fi
-
+current="$(kubectl config current-context || true)"
 selected=$( (kubectl config view -o jsonpath="{.contexts[?(@.name != '${current}')].name}" | xargs -n 1; echo "${current}" ) \
             | fzf -0 -1 --tac -q "${1:-""}" --prompt "$current> ")
 if [ -n "$selected" ]; then

--- a/bin/ktx
+++ b/bin/ktx
@@ -20,8 +20,15 @@ else
   prefix="$(dirname "$0")/.."
 fi
 
-current="$(kubectl config current-context)"
-selected=$( (kubectl config view -o jsonpath="{.contexts[?(@.name != '${current}')].name}" | xargs -n 1; echo "${current}" ) \
+
+exit_code=0; kubectl config current-context || exit_code=$?
+if [[ $exit_code -eq 0 ]]; then
+  current="$(kubectl config current-context)"
+else
+  current=""
+fi
+
+selected=$( (kubectl config view -o jsonpath="{.contexts[?(@.name != '${current}')].name}" | xargs -n 1; echo "${current}\c" ) \
             | fzf -0 -1 --tac -q "${1:-""}" --prompt "$current> ")
 if [ ! -z "$selected" ]; then
   kubectl config use-context "${selected}"


### PR DESCRIPTION
fixes #13

Check for exit code, then set `current` to empty string. This will have no effect on the list of contexts, and also appending it at the end works because of the added control character `\c` which skips the newline.